### PR TITLE
Add WebAssembly binary analysis support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ env_logger = "0.10"
 tokio-test = "0.4"
 # Performance and stress testing
 rand = "0.8"
+wat = "1.0"
 
 [[example]]
 name = "basic_analysis"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A comprehensive Rust library for binary analysis with multi-format support, disa
 - **PE (Portable Executable)**: Windows executables, DLLs, drivers
 - **ELF (Executable and Linkable Format)**: Linux/Unix executables, shared libraries
 - **Mach-O**: macOS executables, dynamic libraries, kernel extensions
-- **WASM**: WebAssembly modules (optional)
+- **WASM**: WebAssembly modules (enable with `wasm` feature)
 - **Java**: JAR files and class files
 - **Raw Binary**: Generic binary file analysis
 
@@ -55,6 +55,7 @@ threatflux-binary-analysis = {
         "pe",              # Windows PE format support
         "elf",             # Linux ELF format support  
         "macho",           # macOS Mach-O format support
+        "wasm",            # WebAssembly module support
         "disasm-capstone", # Capstone disassembly engine
         "control-flow",    # Control flow analysis
         "entropy-analysis",# Statistical analysis
@@ -752,6 +753,7 @@ cargo test --test integration_tests
 
 # Test with different features
 cargo test --features "disasm-capstone,control-flow"
+cargo test --features "wasm"  # Enable WebAssembly support
 
 # Test documentation examples
 cargo test --doc

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -10,8 +10,8 @@ pub mod java;
 pub mod macho;
 #[cfg(feature = "pe")]
 pub mod pe;
-// Note: WebAssembly format parser not yet implemented
-// Format detection is supported but parsing returns UnsupportedFormat error
+#[cfg(feature = "wasm")]
+pub mod wasm;
 
 pub mod raw;
 
@@ -97,6 +97,9 @@ pub fn parse_binary(data: &[u8], format: Format) -> crate::types::ParseResult {
         Format::Java => java::JavaParser::parse(data),
         #[cfg(not(feature = "java"))]
         Format::Java => Err(BinaryError::unsupported_format("Java".to_string())),
+        #[cfg(feature = "wasm")]
+        Format::Wasm => wasm::WasmParser::parse(data),
+        #[cfg(not(feature = "wasm"))]
         Format::Wasm => Err(BinaryError::unsupported_format("Wasm".to_string())),
         Format::Raw => raw::RawParser::parse(data),
         Format::Unknown => Err(BinaryError::unsupported_format("Unknown".to_string())),

--- a/src/formats/wasm.rs
+++ b/src/formats/wasm.rs
@@ -1,0 +1,208 @@
+//! WebAssembly (Wasm) format parser
+
+use crate::{
+    types::{
+        Architecture, BinaryFormat as Format, BinaryMetadata, Endianness, Export, Import, Section,
+        SectionPermissions, SectionType, SecurityFeatures, Symbol,
+    },
+    BinaryFormatParser, BinaryFormatTrait, Result,
+};
+
+use wasmparser::{Parser, Payload};
+
+/// WebAssembly format parser
+pub struct WasmParser;
+
+impl BinaryFormatParser for WasmParser {
+    fn parse(data: &[u8]) -> Result<Box<dyn BinaryFormatTrait>> {
+        Ok(Box::new(WasmBinary::parse(data)?))
+    }
+
+    fn can_parse(data: &[u8]) -> bool {
+        data.len() >= 4 && &data[0..4] == b"\0asm"
+    }
+}
+
+/// Parsed WebAssembly binary
+pub struct WasmBinary {
+    #[allow(dead_code)]
+    data: Vec<u8>,
+    metadata: BinaryMetadata,
+    sections: Vec<Section>,
+    imports: Vec<Import>,
+    exports: Vec<Export>,
+}
+
+impl WasmBinary {
+    fn parse(data: &[u8]) -> Result<Self> {
+        let parser = Parser::new(0);
+        let mut sections = Vec::new();
+        let mut imports = Vec::new();
+        let mut exports = Vec::new();
+        let mut start_fn: Option<u64> = None;
+
+        for payload in parser.parse_all(data) {
+            let payload = payload?;
+            match payload {
+                Payload::Version { .. } => {}
+                Payload::StartSection { func, .. } => {
+                    start_fn = Some(func as u64);
+                }
+                Payload::ImportSection(s) => {
+                    let range = s.range();
+                    for import in s {
+                        let import = import?;
+                        imports.push(Import {
+                            name: import.name.to_string(),
+                            library: Some(import.module.to_string()),
+                            address: None,
+                            ordinal: None,
+                        });
+                    }
+                    sections.push(Section {
+                        name: "import".to_string(),
+                        address: 0,
+                        size: (range.end - range.start) as u64,
+                        offset: range.start as u64,
+                        permissions: SectionPermissions {
+                            read: true,
+                            write: false,
+                            execute: false,
+                        },
+                        section_type: SectionType::Other("Import".to_string()),
+                        data: None,
+                    });
+                }
+                Payload::ExportSection(s) => {
+                    let range = s.range();
+                    for export in s {
+                        let export = export?;
+                        exports.push(Export {
+                            name: export.name.to_string(),
+                            address: 0,
+                            ordinal: None,
+                            forwarded_name: None,
+                        });
+                    }
+                    sections.push(Section {
+                        name: "export".to_string(),
+                        address: 0,
+                        size: (range.end - range.start) as u64,
+                        offset: range.start as u64,
+                        permissions: SectionPermissions {
+                            read: true,
+                            write: false,
+                            execute: false,
+                        },
+                        section_type: SectionType::Other("Export".to_string()),
+                        data: None,
+                    });
+                }
+                Payload::CodeSectionStart { range, .. } => {
+                    sections.push(Section {
+                        name: "code".to_string(),
+                        address: 0,
+                        size: (range.end - range.start) as u64,
+                        offset: range.start as u64,
+                        permissions: SectionPermissions {
+                            read: true,
+                            write: false,
+                            execute: true,
+                        },
+                        section_type: SectionType::Code,
+                        data: None,
+                    });
+                }
+                Payload::DataSection(s) => {
+                    let range = s.range();
+                    // Consume section entries
+                    for _ in s {} // iterating to ensure parser advances
+                    sections.push(Section {
+                        name: "data".to_string(),
+                        address: 0,
+                        size: (range.end - range.start) as u64,
+                        offset: range.start as u64,
+                        permissions: SectionPermissions {
+                            read: true,
+                            write: true,
+                            execute: false,
+                        },
+                        section_type: SectionType::Data,
+                        data: None,
+                    });
+                }
+                Payload::CustomSection(section) => {
+                    let name = section.name().to_string();
+                    sections.push(Section {
+                        name: name.clone(),
+                        address: 0,
+                        size: section.data().len() as u64,
+                        offset: section.data_offset() as u64,
+                        permissions: SectionPermissions {
+                            read: true,
+                            write: false,
+                            execute: false,
+                        },
+                        section_type: SectionType::Other(name),
+                        data: None,
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        let metadata = BinaryMetadata {
+            size: data.len(),
+            format: Format::Wasm,
+            architecture: Architecture::Wasm,
+            entry_point: start_fn,
+            base_address: None,
+            timestamp: None,
+            compiler_info: None,
+            endian: Endianness::Little,
+            security_features: SecurityFeatures::default(),
+        };
+
+        Ok(Self {
+            data: data.to_vec(),
+            metadata,
+            sections,
+            imports,
+            exports,
+        })
+    }
+}
+
+impl BinaryFormatTrait for WasmBinary {
+    fn format_type(&self) -> Format {
+        Format::Wasm
+    }
+
+    fn architecture(&self) -> Architecture {
+        Architecture::Wasm
+    }
+
+    fn entry_point(&self) -> Option<u64> {
+        self.metadata.entry_point
+    }
+
+    fn sections(&self) -> &[Section] {
+        &self.sections
+    }
+
+    fn symbols(&self) -> &[Symbol] {
+        &[]
+    }
+
+    fn imports(&self) -> &[Import] {
+        &self.imports
+    }
+
+    fn exports(&self) -> &[Export] {
+        &self.exports
+    }
+
+    fn metadata(&self) -> &BinaryMetadata {
+        &self.metadata
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -189,7 +189,7 @@ mod test_data {
             0x01, 0x00, 0x00, 0x00, // version 1
             // Type section
             0x01, // section id
-            0x07, // section size
+            0x06, // section size
             0x01, // num types
             0x60, // func type
             0x01, // num params

--- a/tests/wasm_test.rs
+++ b/tests/wasm_test.rs
@@ -1,0 +1,26 @@
+#![cfg(feature = "wasm")]
+//! Tests for WebAssembly binary parsing
+
+use threatflux_binary_analysis::{
+    types::{Architecture, BinaryFormat},
+    BinaryAnalyzer,
+};
+
+#[test]
+fn test_analyze_wasm_binary() {
+    // Simple WebAssembly module exporting a function `add`
+    let wat = r#"(module
+        (func (export "add") (param i32 i32) (result i32)
+            local.get 0
+            local.get 1
+            i32.add))"#;
+    let wasm = wat::parse_str(wat).expect("valid wasm");
+
+    let analyzer = BinaryAnalyzer::new();
+    let analysis = analyzer.analyze(&wasm).expect("analysis succeeds");
+
+    assert_eq!(analysis.format, BinaryFormat::Wasm);
+    assert_eq!(analysis.architecture, Architecture::Wasm);
+    assert!(analysis.exports.iter().any(|e| e.name == "add"));
+    assert!(analysis.sections.iter().any(|s| s.name == "code"));
+}


### PR DESCRIPTION
## Summary
- add `wasm` feature integration and parser
- support parsing WebAssembly modules for sections, imports and exports
- document WebAssembly support and testing instructions

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --features wasm -- -D warnings -A clippy::uninlined-format-args`
- `cargo test`
- `cargo test --features wasm`
- `cargo test --doc`
- `cargo doc --no-deps --features wasm`


------
https://chatgpt.com/codex/tasks/task_e_689f896e8c908327a04512c8a9a9035b