### PR TITLE
Add iced-x86 disassembly support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ threatflux-binary-analysis = {
 | `java` | JAR/class file support | ❌ |
 | `wasm` | WebAssembly support | ❌ |
 | `disasm-capstone` | Capstone disassembly | ✅ |
-| `disasm-iced` | iced-x86 disassembly | ❌ |
+| `disasm-iced` | iced-x86 disassembly | ✅ |
 | `control-flow` | Control flow analysis | ❌ |
 | `entropy-analysis` | Entropy calculation | ❌ |
 | `symbol-resolution` | Debug symbol support | ❌ |
@@ -678,15 +678,32 @@ let elf_analysis = elf_parser.parse(&file_data)?;
 Multiple disassembly engines are supported:
 
 ```rust
+use threatflux_binary_analysis::disasm::{
+    Disassembler, DisassemblyConfig, DisassemblyEngine,
+};
+use threatflux_binary_analysis::types::Architecture;
+
 // Capstone engine (supports many architectures)
-use threatflux_binary_analysis::disasm::CapstoneEngine;
-let capstone = CapstoneEngine::new(Architecture::X86_64)?;
-let instructions = capstone.disassemble(&code, address)?;
+#[cfg(feature = "disasm-capstone")]
+let capstone_cfg = DisassemblyConfig {
+    engine: DisassemblyEngine::Capstone,
+    ..Default::default()
+};
+#[cfg(feature = "disasm-capstone")]
+let capstone = Disassembler::with_config(Architecture::X86_64, capstone_cfg)?;
+#[cfg(feature = "disasm-capstone")]
+let capstone_instructions = capstone.disassemble(&code, address)?;
 
 // iced-x86 engine (x86/x64 only, but very detailed)
-use threatflux_binary_analysis::disasm::IcedEngine;
-let iced = IcedEngine::new(Architecture::X86_64)?;
-let instructions = iced.disassemble(&code, address)?;
+#[cfg(feature = "disasm-iced")]
+let iced_cfg = DisassemblyConfig {
+    engine: DisassemblyEngine::Iced,
+    ..Default::default()
+};
+#[cfg(feature = "disasm-iced")]
+let iced = Disassembler::with_config(Architecture::X86_64, iced_cfg)?;
+#[cfg(feature = "disasm-iced")]
+let iced_instructions = iced.disassemble(&code, address)?;
 ```
 
 ## 📈 Performance

--- a/src/disasm/mod.rs
+++ b/src/disasm/mod.rs
@@ -4,9 +4,12 @@
 //! The choice of engine can be configured based on requirements and availability.
 
 use crate::{
+    types::{Architecture, Instruction, InstructionCategory},
     AnalysisConfig, BinaryError, BinaryFile, Result,
-    types::{Architecture, ControlFlow as FlowType, Instruction, InstructionCategory},
 };
+
+#[cfg(feature = "disasm-capstone")]
+use crate::types::ControlFlow as FlowType;
 
 #[cfg(feature = "disasm-capstone")]
 mod capstone_engine;
@@ -302,6 +305,7 @@ fn categorize_instruction(mnemonic: &str) -> InstructionCategory {
 }
 
 /// Determine control flow type from instruction
+#[cfg(feature = "disasm-capstone")]
 fn analyze_control_flow(mnemonic: &str, operands: &str) -> FlowType {
     let mnemonic_lower = mnemonic.to_lowercase();
 
@@ -335,6 +339,7 @@ fn analyze_control_flow(mnemonic: &str, operands: &str) -> FlowType {
 }
 
 /// Extract address from instruction operands (simplified)
+#[cfg(feature = "disasm-capstone")]
 fn extract_address_from_operands(operands: &str) -> Option<u64> {
     // This is a simplified implementation
     // Real implementation would need proper operand parsing
@@ -389,6 +394,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "disasm-capstone")]
     #[test]
     fn test_control_flow_analysis() {
         assert_eq!(analyze_control_flow("ret", ""), FlowType::Return);
@@ -410,6 +416,8 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "disasm-capstone")]
+    #[cfg(feature = "disasm-capstone")]
     #[test]
     fn test_address_extraction() {
         assert_eq!(extract_address_from_operands("0x1000"), Some(0x1000));

--- a/tests/iced_disasm_test.rs
+++ b/tests/iced_disasm_test.rs
@@ -1,0 +1,24 @@
+//! Tests for iced-x86 disassembly support
+
+#[cfg(feature = "disasm-iced")]
+use threatflux_binary_analysis::disasm::{Disassembler, DisassemblyConfig, DisassemblyEngine};
+#[cfg(feature = "disasm-iced")]
+use threatflux_binary_analysis::types::Architecture;
+
+#[cfg(feature = "disasm-iced")]
+#[test]
+fn test_iced_disassembler_nop() {
+    let config = DisassemblyConfig {
+        engine: DisassemblyEngine::Iced,
+        ..Default::default()
+    };
+    let disassembler = Disassembler::with_config(Architecture::X86_64, config)
+        .expect("failed to create disassembler");
+    let data = [0x90u8, 0x90];
+    let instructions = disassembler
+        .disassemble(&data, 0x1000)
+        .expect("disassembly failed");
+    assert_eq!(instructions.len(), 2);
+    assert_eq!(instructions[0].mnemonic, "nop");
+    assert_eq!(instructions[0].address, 0x1000);
+}


### PR DESCRIPTION
## Summary
- document iced-x86 disassembly feature in the README with usage example
- guard Capstone-specific helpers behind feature flag to keep iced builds clean
- add integration test confirming iced engine disassembles x86 bytes

## Testing
- `cargo clippy --tests --no-deps --features "disasm-iced" -- -A clippy::uninlined_format_args -D warnings`
- `cargo test --features "disasm-iced" -- --nocapture`
- `cargo doc --no-deps --features "disasm-iced"`


------
https://chatgpt.com/codex/tasks/task_e_689f9e4b1b0c832787ea434115d67200