### PR TITLE
Add iced-x86 disassembly support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ threatflux-binary-analysis = {
 | `java` | JAR/class file support | ❌ |
 | `wasm` | WebAssembly support | ❌ |
 | `disasm-capstone` | Capstone disassembly | ✅ |
-| `disasm-iced` | iced-x86 disassembly | ❌ |
+| `disasm-iced` | iced-x86 disassembly | ✅ |
 | `control-flow` | Control flow analysis | ❌ |
 | `entropy-analysis` | Entropy calculation | ❌ |
 | `symbol-resolution` | Debug symbol support | ❌ |
@@ -678,15 +678,32 @@ let elf_analysis = elf_parser.parse(&file_data)?;
 Multiple disassembly engines are supported:
 
 ```rust
+use threatflux_binary_analysis::disasm::{
+    Disassembler, DisassemblyConfig, DisassemblyEngine,
+};
+use threatflux_binary_analysis::types::Architecture;
+
 // Capstone engine (supports many architectures)
-use threatflux_binary_analysis::disasm::CapstoneEngine;
-let capstone = CapstoneEngine::new(Architecture::X86_64)?;
-let instructions = capstone.disassemble(&code, address)?;
+#[cfg(feature = "disasm-capstone")]
+let capstone_cfg = DisassemblyConfig {
+    engine: DisassemblyEngine::Capstone,
+    ..Default::default()
+};
+#[cfg(feature = "disasm-capstone")]
+let capstone = Disassembler::with_config(Architecture::X86_64, capstone_cfg)?;
+#[cfg(feature = "disasm-capstone")]
+let capstone_instructions = capstone.disassemble(&code, address)?;
 
 // iced-x86 engine (x86/x64 only, but very detailed)
-use threatflux_binary_analysis::disasm::IcedEngine;
-let iced = IcedEngine::new(Architecture::X86_64)?;
-let instructions = iced.disassemble(&code, address)?;
+#[cfg(feature = "disasm-iced")]
+let iced_cfg = DisassemblyConfig {
+    engine: DisassemblyEngine::Iced,
+    ..Default::default()
+};
+#[cfg(feature = "disasm-iced")]
+let iced = Disassembler::with_config(Architecture::X86_64, iced_cfg)?;
+#[cfg(feature = "disasm-iced")]
+let iced_instructions = iced.disassemble(&code, address)?;
 ```
 
 ## 📈 Performance

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -6,8 +6,8 @@
 use std::env;
 use std::fs;
 use threatflux_binary_analysis::{
-    BinaryFile,
     analysis::control_flow::{AnalysisConfig, ControlFlowAnalyzer},
+    BinaryFile,
 };
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;

--- a/examples/disassembly.rs
+++ b/examples/disassembly.rs
@@ -6,9 +6,9 @@
 use std::env;
 use std::fs;
 use threatflux_binary_analysis::{
-    BinaryFile,
     disasm::{Disassembler, DisassemblyConfig, DisassemblyEngine},
     types::ControlFlow,
+    BinaryFile,
 };
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;

--- a/examples/security_analysis.rs
+++ b/examples/security_analysis.rs
@@ -6,9 +6,9 @@
 use std::env;
 use std::fs;
 use threatflux_binary_analysis::{
-    BinaryFile,
     analysis::security::{SecurityAnalyzer, SecurityConfig},
     utils::patterns::{PatternCategory, PatternMatcher},
+    BinaryFile,
 };
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;

--- a/src/analysis/control_flow.rs
+++ b/src/analysis/control_flow.rs
@@ -5,11 +5,11 @@
 //! complexity metrics calculation.
 
 use crate::{
-    BinaryFile, Result,
     types::{
         Architecture, BasicBlock, ComplexityMetrics, ControlFlow as FlowType, ControlFlowGraph,
         Function, Instruction, InstructionCategory,
     },
+    BinaryFile, Result,
 };
 use std::collections::{HashMap, HashSet};
 

--- a/src/analysis/entropy.rs
+++ b/src/analysis/entropy.rs
@@ -1,8 +1,8 @@
 //! Entropy analysis for binary files
 
 use crate::{
-    BinaryFile, Result,
     types::{EntropyAnalysis, EntropyRegion, ObfuscationLevel, PackingIndicators},
+    BinaryFile, Result,
 };
 use std::collections::HashMap;
 

--- a/src/analysis/security.rs
+++ b/src/analysis/security.rs
@@ -4,8 +4,8 @@
 //! including vulnerability detection, malware indicators, and security feature analysis.
 
 use crate::{
-    BinaryFile, Result,
     types::{Architecture, Import, Section, SecurityFeatures, SecurityIndicators, Symbol},
+    BinaryFile, Result,
 };
 use std::collections::HashSet;
 
@@ -828,16 +828,12 @@ mod tests {
         analyzer.analyze_imports(&imports, &mut indicators, &mut findings);
 
         assert_eq!(indicators.suspicious_apis.len(), 2);
-        assert!(
-            indicators
-                .suspicious_apis
-                .contains(&"VirtualAllocEx".to_string())
-        );
-        assert!(
-            indicators
-                .suspicious_apis
-                .contains(&"WriteProcessMemory".to_string())
-        );
+        assert!(indicators
+            .suspicious_apis
+            .contains(&"VirtualAllocEx".to_string()));
+        assert!(indicators
+            .suspicious_apis
+            .contains(&"WriteProcessMemory".to_string()));
 
         let suspicious_findings: Vec<_> = findings
             .iter()
@@ -871,16 +867,12 @@ mod tests {
         analyzer.analyze_imports(&imports, &mut indicators, &mut findings);
 
         assert_eq!(indicators.anti_debug.len(), 2);
-        assert!(
-            indicators
-                .anti_debug
-                .contains(&"IsDebuggerPresent".to_string())
-        );
-        assert!(
-            indicators
-                .anti_debug
-                .contains(&"CheckRemoteDebuggerPresent".to_string())
-        );
+        assert!(indicators
+            .anti_debug
+            .contains(&"IsDebuggerPresent".to_string()));
+        assert!(indicators
+            .anti_debug
+            .contains(&"CheckRemoteDebuggerPresent".to_string()));
 
         let anti_debug_findings: Vec<_> = findings
             .iter()
@@ -1222,16 +1214,12 @@ mod tests {
         // Check specific findings
         assert!(findings.iter().any(|f| f.description.contains("NX/DEP")));
         assert!(findings.iter().any(|f| f.description.contains("ASLR")));
-        assert!(
-            findings
-                .iter()
-                .any(|f| f.description.contains("Stack canaries"))
-        );
-        assert!(
-            findings
-                .iter()
-                .any(|f| f.description.contains("Control Flow Integrity"))
-        );
+        assert!(findings
+            .iter()
+            .any(|f| f.description.contains("Stack canaries")));
+        assert!(findings
+            .iter()
+            .any(|f| f.description.contains("Control Flow Integrity")));
     }
 
     #[test]
@@ -1794,26 +1782,20 @@ mod tests {
 
         // Verify high-risk indicators
         assert!(!result.indicators.suspicious_apis.is_empty());
-        assert!(
-            result
-                .indicators
-                .suspicious_apis
-                .contains(&"VirtualAllocEx".to_string())
-        );
-        assert!(
-            result
-                .indicators
-                .suspicious_apis
-                .contains(&"WriteProcessMemory".to_string())
-        );
+        assert!(result
+            .indicators
+            .suspicious_apis
+            .contains(&"VirtualAllocEx".to_string()));
+        assert!(result
+            .indicators
+            .suspicious_apis
+            .contains(&"WriteProcessMemory".to_string()));
 
         assert!(!result.indicators.anti_debug.is_empty());
-        assert!(
-            result
-                .indicators
-                .anti_debug
-                .contains(&"IsDebuggerPresent".to_string())
-        );
+        assert!(result
+            .indicators
+            .anti_debug
+            .contains(&"IsDebuggerPresent".to_string()));
 
         // Verify security features
         assert!(!result.features.nx_bit);
@@ -2039,12 +2021,10 @@ mod tests {
         assert!(!result.findings.is_empty());
 
         // Verify that the function detected the suspicious API from our test data
-        assert!(
-            result
-                .indicators
-                .suspicious_apis
-                .contains(&"VirtualAllocEx".to_string())
-        );
+        assert!(result
+            .indicators
+            .suspicious_apis
+            .contains(&"VirtualAllocEx".to_string()));
     }
 
     #[test]

--- a/src/disasm/capstone_engine.rs
+++ b/src/disasm/capstone_engine.rs
@@ -1,9 +1,9 @@
 //! Capstone disassembly engine implementation
 
-use super::{DisassemblyConfig, analyze_control_flow, categorize_instruction};
+use super::{analyze_control_flow, categorize_instruction, DisassemblyConfig};
 use crate::{
-    BinaryError, Result,
     types::{Architecture, ControlFlow as FlowType, Instruction},
+    BinaryError, Result,
 };
 use capstone::prelude::*;
 use capstone::{Arch, Mode};

--- a/src/disasm/iced_engine.rs
+++ b/src/disasm/iced_engine.rs
@@ -1,9 +1,9 @@
 //! iced-x86 disassembly engine implementation
 
-use super::{DisassemblyConfig, categorize_instruction};
+use super::{categorize_instruction, DisassemblyConfig};
 use crate::{
-    BinaryError, Result,
     types::{Architecture, ControlFlow as FlowType, Instruction},
+    BinaryError, Result,
 };
 use iced_x86::*;
 

--- a/src/disasm/mod.rs
+++ b/src/disasm/mod.rs
@@ -4,9 +4,12 @@
 //! The choice of engine can be configured based on requirements and availability.
 
 use crate::{
+    types::{Architecture, Instruction, InstructionCategory},
     AnalysisConfig, BinaryError, BinaryFile, Result,
-    types::{Architecture, ControlFlow as FlowType, Instruction, InstructionCategory},
 };
+
+#[cfg(feature = "disasm-capstone")]
+use crate::types::ControlFlow as FlowType;
 
 #[cfg(feature = "disasm-capstone")]
 mod capstone_engine;
@@ -302,6 +305,7 @@ fn categorize_instruction(mnemonic: &str) -> InstructionCategory {
 }
 
 /// Determine control flow type from instruction
+#[cfg(feature = "disasm-capstone")]
 fn analyze_control_flow(mnemonic: &str, operands: &str) -> FlowType {
     let mnemonic_lower = mnemonic.to_lowercase();
 
@@ -335,6 +339,7 @@ fn analyze_control_flow(mnemonic: &str, operands: &str) -> FlowType {
 }
 
 /// Extract address from instruction operands (simplified)
+#[cfg(feature = "disasm-capstone")]
 fn extract_address_from_operands(operands: &str) -> Option<u64> {
     // This is a simplified implementation
     // Real implementation would need proper operand parsing
@@ -389,6 +394,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "disasm-capstone")]
     #[test]
     fn test_control_flow_analysis() {
         assert_eq!(analyze_control_flow("ret", ""), FlowType::Return);
@@ -410,6 +416,8 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "disasm-capstone")]
+    #[cfg(feature = "disasm-capstone")]
     #[test]
     fn test_address_extraction() {
         assert_eq!(extract_address_from_operands("0x1000"), Some(0x1000));

--- a/src/error.rs
+++ b/src/error.rs
@@ -347,11 +347,9 @@ mod tests {
         let binary_err: BinaryError = goblin_err.into();
 
         assert!(matches!(binary_err, BinaryError::ParseError(_)));
-        assert!(
-            binary_err
-                .to_string()
-                .contains("Failed to parse binary format")
-        );
+        assert!(binary_err
+            .to_string()
+            .contains("Failed to parse binary format"));
         assert!(binary_err.to_string().contains("invalid header"));
     }
 
@@ -425,11 +423,9 @@ mod tests {
         let binary_err: BinaryError = wasm_err.into();
 
         assert!(matches!(binary_err, BinaryError::ParseError(_)));
-        assert!(
-            binary_err
-                .to_string()
-                .contains("Failed to parse binary format")
-        );
+        assert!(binary_err
+            .to_string()
+            .contains("Failed to parse binary format"));
         assert!(binary_err.to_string().contains("WASM parse error"));
     }
 

--- a/src/formats/elf.rs
+++ b/src/formats/elf.rs
@@ -1,12 +1,12 @@
 //! ELF format parser
 
 use crate::{
-    BinaryFormatParser, BinaryFormatTrait, Result,
     types::{
         Architecture, BinaryFormat as Format, BinaryMetadata, Endianness, Export, Import, Section,
         SectionPermissions, SectionType, SecurityFeatures, Symbol, SymbolBinding, SymbolType,
         SymbolVisibility,
     },
+    BinaryFormatParser, BinaryFormatTrait, Result,
 };
 use goblin::elf::Elf;
 

--- a/src/formats/java.rs
+++ b/src/formats/java.rs
@@ -1,12 +1,12 @@
 //! Java class and JAR file parser
 
 use crate::{
-    BinaryError, BinaryFormatParser, BinaryFormatTrait, Result,
     types::{
         Architecture, BinaryFormat as Format, BinaryMetadata, Endianness, Export, Import, Section,
         SectionPermissions, SectionType, SecurityFeatures, Symbol, SymbolBinding, SymbolType,
         SymbolVisibility,
     },
+    BinaryError, BinaryFormatParser, BinaryFormatTrait, Result,
 };
 
 type ParseResult = Result<Box<dyn BinaryFormatTrait>>;

--- a/src/formats/macho.rs
+++ b/src/formats/macho.rs
@@ -1,11 +1,11 @@
 //! Mach-O format parser for macOS/iOS binaries
 
 use crate::{
-    BinaryError, BinaryFormatParser, BinaryFormatTrait, Result,
     types::{
         Architecture, BinaryFormat as Format, BinaryMetadata, Endianness, Export, Import, Section,
         SectionPermissions, SectionType, SecurityFeatures, Symbol,
     },
+    BinaryError, BinaryFormatParser, BinaryFormatTrait, Result,
 };
 use goblin::mach::{Mach, MachO};
 

--- a/src/formats/pe.rs
+++ b/src/formats/pe.rs
@@ -1,13 +1,13 @@
 //! PE (Portable Executable) format parser for Windows binaries
 
 use crate::{
-    BinaryFormatParser, BinaryFormatTrait, Result,
     types::{
         Architecture, BinaryFormat as Format, BinaryMetadata, Endianness, Export, Import, Section,
         SectionPermissions, SectionType, SecurityFeatures, Symbol,
     },
+    BinaryFormatParser, BinaryFormatTrait, Result,
 };
-use goblin::pe::{PE, dll_characteristic::*};
+use goblin::pe::{dll_characteristic::*, PE};
 
 /// PE format parser
 pub struct PeParser;

--- a/src/formats/raw.rs
+++ b/src/formats/raw.rs
@@ -1,11 +1,11 @@
 //! Raw binary format parser
 
 use crate::{
-    BinaryFormatParser, BinaryFormatTrait, Result,
     types::{
         Architecture, BinaryFormat as Format, BinaryMetadata, Endianness, Export, Import, Section,
         SectionPermissions, SectionType, SecurityFeatures, Symbol,
     },
+    BinaryFormatParser, BinaryFormatTrait, Result,
 };
 
 /// Raw binary format parser

--- a/src/utils/mmap.rs
+++ b/src/utils/mmap.rs
@@ -426,12 +426,10 @@ mod tests {
         // Test error case - range exceeds file size
         let result = mapped.slice(0..100);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Range exceeds file size")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Range exceeds file size"));
     }
 
     #[test]
@@ -460,12 +458,10 @@ mod tests {
         // Test read_at with out of bounds
         let result = mapped.read_at(0, 100);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Read exceeds file size")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Read exceeds file size"));
 
         // Test read_at with offset out of bounds
         let result = mapped.read_at(50, 5);
@@ -478,12 +474,10 @@ mod tests {
         // Test read_u8 with offset out of bounds
         let result = mapped.read_u8(100);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Offset exceeds file size")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Offset exceeds file size"));
     }
 
     #[test]
@@ -566,12 +560,10 @@ mod tests {
         // Test invalid UTF-8 string
         let result = mapped.read_cstring(0, 10);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Invalid UTF-8 string")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Invalid UTF-8 string"));
     }
 
     #[test]
@@ -674,12 +666,10 @@ mod tests {
         // Test error case
         let result = mapped.view(0..100);
         assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("Range exceeds file size")
-        );
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Range exceeds file size"));
     }
 
     #[test]

--- a/src/utils/patterns.rs
+++ b/src/utils/patterns.rs
@@ -1196,11 +1196,9 @@ mod tests {
 
         assert_eq!(results.matches.len(), 2);
         assert_eq!(results.by_category.len(), 2);
-        assert!(
-            results
-                .by_category
-                .contains_key(&PatternCategory::FileFormat)
-        );
+        assert!(results
+            .by_category
+            .contains_key(&PatternCategory::FileFormat));
         assert!(results.by_category.contains_key(&PatternCategory::Compiler));
     }
 

--- a/tests/elf_test.rs
+++ b/tests/elf_test.rs
@@ -1,8 +1,8 @@
 //! Tests for ELF format parser
 
-use threatflux_binary_analysis::BinaryFormatParser;
 use threatflux_binary_analysis::formats::elf::ElfParser;
 use threatflux_binary_analysis::types::*;
+use threatflux_binary_analysis::BinaryFormatParser;
 
 /// Test data generators for various ELF formats
 mod elf_test_data {

--- a/tests/format_detection_test.rs
+++ b/tests/format_detection_test.rs
@@ -71,7 +71,7 @@ fn test_detect_java_format() {
 #[test]
 fn test_detect_java_jar_format() {
     use std::io::Write;
-    use zip::{ZipWriter, write::FileOptions};
+    use zip::{write::FileOptions, ZipWriter};
 
     let mut cursor = std::io::Cursor::new(Vec::new());
     {

--- a/tests/iced_disasm_test.rs
+++ b/tests/iced_disasm_test.rs
@@ -1,0 +1,24 @@
+//! Tests for iced-x86 disassembly support
+
+#[cfg(feature = "disasm-iced")]
+use threatflux_binary_analysis::disasm::{Disassembler, DisassemblyConfig, DisassemblyEngine};
+#[cfg(feature = "disasm-iced")]
+use threatflux_binary_analysis::types::Architecture;
+
+#[cfg(feature = "disasm-iced")]
+#[test]
+fn test_iced_disassembler_nop() {
+    let config = DisassemblyConfig {
+        engine: DisassemblyEngine::Iced,
+        ..Default::default()
+    };
+    let disassembler = Disassembler::with_config(Architecture::X86_64, config)
+        .expect("failed to create disassembler");
+    let data = [0x90u8, 0x90];
+    let instructions = disassembler
+        .disassemble(&data, 0x1000)
+        .expect("disassembly failed");
+    assert_eq!(instructions.len(), 2);
+    assert_eq!(instructions[0].mnemonic, "nop");
+    assert_eq!(instructions[0].address, 0x1000);
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -216,7 +216,7 @@ mod test_data {
 
     pub fn create_java_jar() -> Vec<u8> {
         use std::io::Write;
-        use zip::{ZipWriter, write::FileOptions};
+        use zip::{write::FileOptions, ZipWriter};
 
         let class_data = create_java_class();
         let cursor = std::io::Cursor::new(Vec::new());


### PR DESCRIPTION
## Summary
- document iced-x86 disassembly feature in the README with usage example
- guard Capstone-specific helpers behind feature flag to keep iced builds clean
- add integration test confirming iced engine disassembles x86 bytes
- merge latest `main` into feature branch to resolve conflicts

## Testing
- `cargo clippy --tests --no-deps --features "disasm-iced" -- -A clippy::uninlined_format_args -D warnings`
- `cargo test --quiet --features "disasm-iced" -- --nocapture`
- `cargo doc --no-deps --features "disasm-iced"`


------
https://chatgpt.com/codex/tasks/task_e_689f9e4b1b0c832787ea434115d67200