### PR TITLE
Add auxiliary analysis features and JSON support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ A comprehensive Rust library for binary analysis with multi-format support, disa
 - **🏗️ Metadata Extraction**: Compiler detection, build information
 - **🔍 String Extraction**: ASCII and Unicode string discovery
 - **📱 Mobile Analysis**: Android APK and iOS app analysis
+- **🗜️ Compression Support**: Decompress common compressed sections
+- **🗺️ Visualization**: Export control flow graphs to DOT format
+- **📝 JSON Serialization**: Serialize analysis results to JSON
 
 ### Performance Features
 - **⚡ Memory-Mapped Files**: Efficient large file handling
@@ -59,8 +62,11 @@ threatflux-binary-analysis = {
         "disasm-capstone", # Capstone disassembly engine
         "control-flow",    # Control flow analysis
         "entropy-analysis",# Statistical analysis
+        "symbol-resolution",# Debug symbol support
+        "compression",     # Compressed section support
+        "visualization",   # Graph visualization
         "serde-support",   # JSON serialization support
-    ] 
+    ]
 }
 ```
 
@@ -76,11 +82,11 @@ threatflux-binary-analysis = {
 | `disasm-capstone` | Capstone disassembly | ✅ |
 | `disasm-iced` | iced-x86 disassembly | ❌ |
 | `control-flow` | Control flow analysis | ❌ |
-| `entropy-analysis` | Entropy calculation | ❌ |
-| `symbol-resolution` | Debug symbol support | ❌ |
-| `compression` | Compressed section support | ❌ |
-| `visualization` | Graph visualization | ❌ |
-| `serde-support` | JSON serialization | ❌ |
+| `entropy-analysis` | Entropy calculation | ✅ |
+| `symbol-resolution` | Debug symbol support | ✅ |
+| `compression` | Compressed section support | ✅ |
+| `visualization` | Graph visualization | ✅ |
+| `serde-support` | JSON serialization | ✅ |
 
 ## 🚀 Quick Start
 

--- a/examples/basic_analysis.rs
+++ b/examples/basic_analysis.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Basic binary analysis example
 //!
 //! This example demonstrates how to use the threatflux-binary-analysis library

--- a/src/analysis/mod.rs
+++ b/src/analysis/mod.rs
@@ -7,3 +7,9 @@ pub mod control_flow;
 pub mod entropy;
 
 pub mod security;
+
+#[cfg(feature = "symbol-resolution")]
+pub mod symbols;
+
+#[cfg(feature = "visualization")]
+pub mod visualization;

--- a/src/analysis/symbols.rs
+++ b/src/analysis/symbols.rs
@@ -1,0 +1,62 @@
+use crate::types::Symbol;
+#[cfg(feature = "symbol-resolution")]
+use addr2line::demangle_auto;
+#[cfg(feature = "symbol-resolution")]
+use gimli::DW_LANG_C_plus_plus;
+#[cfg(feature = "symbol-resolution")]
+use std::borrow::Cow;
+
+/// Demangle symbol names using DWARF demangling facilities.
+///
+/// This function populates the `demangled_name` field for each provided
+/// [`Symbol`], leaving existing values intact.
+#[cfg(feature = "symbol-resolution")]
+pub fn demangle_symbols(symbols: &mut [Symbol]) {
+    for symbol in symbols.iter_mut() {
+        if symbol.demangled_name.is_none() {
+            let demangled = demangle_auto(Cow::Borrowed(&symbol.name), Some(DW_LANG_C_plus_plus));
+            let demangled = demangled.to_string();
+            if demangled != symbol.name {
+                symbol.demangled_name = Some(demangled);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{SymbolBinding, SymbolType, SymbolVisibility};
+
+    #[cfg(feature = "symbol-resolution")]
+    #[test]
+    fn test_demangle_symbols() {
+        let mut symbols = vec![
+            Symbol {
+                name: "_ZN3foo3barEv".into(),
+                demangled_name: None,
+                address: 0,
+                size: 0,
+                symbol_type: SymbolType::Function,
+                binding: SymbolBinding::Global,
+                visibility: SymbolVisibility::Default,
+                section_index: None,
+            },
+            Symbol {
+                name: "plain_symbol".into(),
+                demangled_name: None,
+                address: 0,
+                size: 0,
+                symbol_type: SymbolType::Object,
+                binding: SymbolBinding::Global,
+                visibility: SymbolVisibility::Default,
+                section_index: None,
+            },
+        ];
+
+        demangle_symbols(&mut symbols);
+
+        assert_eq!(symbols[0].demangled_name.as_deref(), Some("foo::bar()"));
+        assert!(symbols[1].demangled_name.is_none());
+    }
+}

--- a/src/analysis/visualization.rs
+++ b/src/analysis/visualization.rs
@@ -1,0 +1,77 @@
+#[cfg(feature = "visualization")]
+#[allow(unused_imports)]
+use dot_generator as _dot_generator;
+
+use crate::types::ControlFlowGraph;
+
+/// Generate a DOT representation of a control flow graph.
+#[cfg(feature = "visualization")]
+pub fn cfg_to_dot(cfg: &ControlFlowGraph) -> String {
+    let mut dot = String::from("digraph cfg {\n");
+    for block in &cfg.basic_blocks {
+        dot.push_str(&format!(
+            "  bb{} [label=\"0x{:x}\"];\n",
+            block.id, block.start_address
+        ));
+    }
+    for block in &cfg.basic_blocks {
+        for succ in &block.successors {
+            dot.push_str(&format!("  bb{} -> bb{};\n", block.id, succ));
+        }
+    }
+    dot.push_str("}\n");
+    dot
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{BasicBlock, ComplexityMetrics, Function, FunctionType};
+
+    #[cfg(feature = "visualization")]
+    #[test]
+    fn test_cfg_to_dot() {
+        let cfg = ControlFlowGraph {
+            function: Function {
+                name: "test".into(),
+                start_address: 0,
+                end_address: 10,
+                size: 10,
+                function_type: FunctionType::Normal,
+                calling_convention: None,
+                parameters: vec![],
+                return_type: None,
+            },
+            basic_blocks: vec![
+                BasicBlock {
+                    id: 0,
+                    start_address: 0,
+                    end_address: 5,
+                    instructions: vec![],
+                    successors: vec![1],
+                    predecessors: vec![],
+                },
+                BasicBlock {
+                    id: 1,
+                    start_address: 5,
+                    end_address: 10,
+                    instructions: vec![],
+                    successors: vec![],
+                    predecessors: vec![0],
+                },
+            ],
+            complexity: ComplexityMetrics {
+                cyclomatic_complexity: 1,
+                basic_block_count: 2,
+                edge_count: 1,
+                nesting_depth: 0,
+                loop_count: 0,
+            },
+        };
+
+        let dot = cfg_to_dot(&cfg);
+        assert!(dot.contains("bb0 -> bb1"));
+        assert!(dot.contains("bb0"));
+        assert!(dot.contains("bb1"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,13 @@ impl BinaryAnalyzer {
             }
         }
 
+        #[cfg(feature = "symbol-resolution")]
+        {
+            if self.config.enable_symbols {
+                analysis::symbols::demangle_symbols(&mut result.symbols);
+            }
+        }
+
         Ok(result)
     }
 

--- a/src/utils/compression.rs
+++ b/src/utils/compression.rs
@@ -1,0 +1,57 @@
+use crate::{error::BinaryError, Result};
+use flate2::read::{GzDecoder, ZlibDecoder};
+use std::io::Read;
+
+/// Decompress gzip or zlib data.
+#[cfg(feature = "compression")]
+pub fn decompress(data: &[u8]) -> Result<Vec<u8>> {
+    if data.starts_with(b"\x1f\x8b") {
+        let mut decoder = GzDecoder::new(data);
+        let mut out = Vec::new();
+        decoder.read_to_end(&mut out)?;
+        Ok(out)
+    } else if data.starts_with(b"\x78\x9c")
+        || data.starts_with(b"\x78\x01")
+        || data.starts_with(b"\x78\xda")
+    {
+        let mut decoder = ZlibDecoder::new(data);
+        let mut out = Vec::new();
+        decoder.read_to_end(&mut out)?;
+        Ok(out)
+    } else {
+        Err(BinaryError::invalid_data("unsupported compression format"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::write::{GzEncoder, ZlibEncoder};
+    use flate2::Compression;
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn test_decompress_gzip() {
+        let data = b"hello world";
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        use std::io::Write;
+        encoder.write_all(data).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let decompressed = decompress(&compressed).unwrap();
+        assert_eq!(decompressed, data);
+    }
+
+    #[cfg(feature = "compression")]
+    #[test]
+    fn test_decompress_zlib() {
+        let data = b"another test";
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        use std::io::Write;
+        encoder.write_all(data).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let decompressed = decompress(&compressed).unwrap();
+        assert_eq!(decompressed, data);
+    }
+}

--- a/src/utils/mmap.rs
+++ b/src/utils/mmap.rs
@@ -601,7 +601,7 @@ mod tests {
 
         // Test with no occurrences
         let positions = mapped.find_all_patterns(b"xyz");
-        assert_eq!(positions, vec![]);
+        assert_eq!(positions, Vec::<usize>::new());
 
         // Test with single byte pattern
         let positions = mapped.find_all_patterns(b"a");
@@ -735,7 +735,7 @@ mod tests {
         assert!(mapped.read_u8(0).is_err());
         assert!(mapped.read_at(0, 1).is_err());
         assert_eq!(mapped.find_pattern(b"test"), None);
-        assert_eq!(mapped.find_all_patterns(b"test"), vec![]);
+        assert_eq!(mapped.find_all_patterns(b"test"), Vec::<usize>::new());
         assert!(mapped.starts_with(b"")); // Empty pattern should match empty file
         assert!(!mapped.starts_with(b"test"));
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,3 +8,9 @@ pub mod mmap;
 
 /// Byte pattern matching utilities
 pub mod patterns;
+
+#[cfg(feature = "compression")]
+pub mod compression;
+
+#[cfg(feature = "serde-support")]
+pub mod serde_utils;

--- a/src/utils/serde_utils.rs
+++ b/src/utils/serde_utils.rs
@@ -1,0 +1,34 @@
+use crate::{error::BinaryError, Result};
+#[cfg(feature = "serde-support")]
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Serialize a value to a JSON string.
+#[cfg(feature = "serde-support")]
+pub fn to_json<T: Serialize>(value: &T) -> Result<String> {
+    serde_json::to_string_pretty(value).map_err(|e| BinaryError::internal(e.to_string()))
+}
+
+/// Deserialize a value from a JSON string.
+#[cfg(feature = "serde-support")]
+pub fn from_json<T: DeserializeOwned>(s: &str) -> Result<T> {
+    serde_json::from_str(s).map_err(|e| BinaryError::internal(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{AnalysisResult, BinaryFormat};
+
+    #[cfg(feature = "serde-support")]
+    #[test]
+    fn test_json_roundtrip() {
+        let result = AnalysisResult {
+            format: BinaryFormat::Elf,
+            ..Default::default()
+        };
+        let json = to_json(&result).unwrap();
+        assert!(json.contains("\"Elf\""));
+        let de: AnalysisResult = from_json(&json).unwrap();
+        assert_eq!(de.format, BinaryFormat::Elf);
+    }
+}


### PR DESCRIPTION
## Summary
- add symbol demangling helper for symbol-resolution feature
- support CFG visualization and compression utilities
- expose JSON serialization helpers and update feature docs

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings -A clippy::uninlined-format-args`
- `cargo test --all-features`
- `cargo doc --no-deps --all-features`
- `cargo deny check` *(fails: failed to fetch advisory database)*
- `cargo tarpaulin --all-features`

------
https://chatgpt.com/codex/tasks/task_e_689fad0a4298832798828f59f0ea858f