### PR TITLE
Document feature flags and clean up formatting

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,6 +12,7 @@ This document provides a comprehensive reference for the ThreatFlux Binary Analy
 - [Utility APIs](#utility-apis)
 - [Error Handling](#error-handling)
 - [Configuration](#configuration)
+- [Feature Flags](#feature-flags)
 
 ## Core API
 
@@ -1236,3 +1237,27 @@ impl Default for AnalysisConfig {
 ```
 
 This comprehensive API reference covers all major components of the ThreatFlux Binary Analysis library. For more specific usage examples and implementation details, refer to the individual module documentation and example code.
+
+## Feature Flags
+
+| Feature | Description | Default |
+|---------|-------------|---------|
+| `elf` | ELF format support | ✅ |
+| `pe` | PE format support | ✅ |
+| `macho` | Mach-O format support | ✅ |
+| `java` | JAR/class file support | ✅ |
+| `wasm` | WebAssembly support | ❌ |
+| `disasm-capstone` | Capstone disassembly | ✅ |
+| `disasm-iced` | iced-x86 disassembly | ❌ |
+| `control-flow` | Control flow analysis | ❌ |
+| `entropy-analysis` | Entropy calculation | ✅ |
+| `symbol-resolution` | Debug symbol support | ✅ |
+| `compression` | Compressed section support | ✅ |
+| `visualization` | Graph visualization | ✅ |
+| `serde-support` | JSON serialization | ✅ |
+
+Enable optional capabilities using Cargo feature flags, for example:
+
+```bash
+cargo build --features "wasm,control-flow"
+```

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ threatflux-binary-analysis = {
 | `elf` | ELF format support | ✅ |
 | `pe` | PE format support | ✅ |
 | `macho` | Mach-O format support | ✅ |
-| `java` | JAR/class file support | ❌ |
+| `java` | JAR/class file support | ✅ |
 | `wasm` | WebAssembly support | ❌ |
 | `disasm-capstone` | Capstone disassembly | ✅ |
 | `disasm-iced` | iced-x86 disassembly | ❌ |
@@ -90,6 +90,10 @@ threatflux-binary-analysis = {
 | `serde-support` | JSON serialization | ✅ |
 
 *The `disasm-iced` feature enables the [iced-x86](https://github.com/icedland/iced) disassembly engine. Activate it with `--features "disasm-iced"` to use iced-x86 instead of Capstone.*
+
+*Enable WebAssembly module parsing with `--features "wasm"`.*
+
+*Generate control flow graphs with `--features "control-flow"`.*
 
 ## 🚀 Quick Start
 

--- a/examples/disassembly.rs
+++ b/examples/disassembly.rs
@@ -22,7 +22,7 @@ fn main() -> Result<()> {
     }
 
     let file_path = &args[1];
-    println!("Disassembling binary file: {}", file_path);
+    println!("Disassembling binary file: {file_path}");
 
     // Read and parse the binary file
     let data = fs::read(file_path)?;
@@ -75,7 +75,11 @@ fn main() -> Result<()> {
                         analyze_instruction_stats(&instructions);
                     }
                     Err(e) => {
-                        eprintln!("Failed to disassemble section {}: {}", section.name, e);
+                        eprintln!(
+                            "Failed to disassemble section {name}: {e}",
+                            name = section.name,
+                            e = e
+                        );
                     }
                 }
             } else {
@@ -85,12 +89,12 @@ fn main() -> Result<()> {
     }
 
     println!("\n=== Summary ===");
-    println!("Total instructions disassembled: {}", total_instructions);
+    println!("Total instructions disassembled: {total_instructions}");
 
     // Try to disassemble from entry point if available
     if let Some(entry_point) = binary.entry_point() {
         println!("\n=== Entry Point Analysis ===");
-        println!("Entry point: 0x{:x}", entry_point);
+        println!("Entry point: 0x{entry_point:x}");
 
         // Find the section containing the entry point
         for section in binary.sections() {
@@ -111,7 +115,7 @@ fn main() -> Result<()> {
                                 }
                             }
                             Err(e) => {
-                                eprintln!("Failed to disassemble entry point: {}", e);
+                                eprintln!("Failed to disassemble entry point: {e}");
                             }
                         }
                     }
@@ -130,7 +134,7 @@ fn print_instruction(index: usize, instr: &threatflux_binary_analysis::types::In
     let bytes_str = instr
         .bytes
         .iter()
-        .map(|b| format!("{:02x}", b))
+        .map(|b| format!("{b:02x}"))
         .collect::<Vec<_>>()
         .join(" ");
 
@@ -150,15 +154,15 @@ fn print_instruction(index: usize, instr: &threatflux_binary_analysis::types::In
     let category_str = format!("{:?}", instr.category);
     let flow_info = match &instr.flow {
         ControlFlow::Sequential => "sequential".to_string(),
-        ControlFlow::Jump(addr) => format!("jmp -> 0x{:x}", addr),
-        ControlFlow::ConditionalJump(addr) => format!("branch -> 0x{:x}", addr),
-        ControlFlow::Call(addr) => format!("call -> 0x{:x}", addr),
+        ControlFlow::Jump(addr) => format!("jmp -> 0x{addr:x}"),
+        ControlFlow::ConditionalJump(addr) => format!("branch -> 0x{addr:x}"),
+        ControlFlow::Call(addr) => format!("call -> 0x{addr:x}"),
         ControlFlow::Return => "return".to_string(),
         ControlFlow::Interrupt => "interrupt".to_string(),
         ControlFlow::Unknown => "unknown".to_string(),
     };
 
-    println!("      [{}] [{}]", category_str, flow_info);
+    println!("      [{category_str}] [{flow_info}]");
 }
 
 /// Analyze and print instruction statistics
@@ -187,7 +191,7 @@ fn analyze_instruction_stats(instructions: &[threatflux_binary_analysis::types::
 
     for (category, count) in categories.iter().take(5) {
         let percentage = (**count as f64 / instructions.len() as f64) * 100.0;
-        println!("  {:?}: {} ({:.1}%)", category, count, percentage);
+        println!("  {category:?}: {count} ({percentage:.1}%)");
     }
 
     // Print control flow distribution
@@ -197,7 +201,7 @@ fn analyze_instruction_stats(instructions: &[threatflux_binary_analysis::types::
 
     for (flow, count) in flows.iter().take(10) {
         let percentage = (**count as f64 / instructions.len() as f64) * 100.0;
-        println!("  {}: {} ({:.1}%)", flow, count, percentage);
+        println!("  {flow}: {count} ({percentage:.1}%)");
     }
 
     // Print most common mnemonics
@@ -207,13 +211,13 @@ fn analyze_instruction_stats(instructions: &[threatflux_binary_analysis::types::
 
     for (mnemonic, count) in mnemonics.iter().take(10) {
         let percentage = (**count as f64 / instructions.len() as f64) * 100.0;
-        println!("  {}: {} ({:.1}%)", mnemonic, count, percentage);
+        println!("  {mnemonic}: {count} ({percentage:.1}%)");
     }
 
     // Calculate average instruction size
     let total_size: usize = instructions.iter().map(|i| i.size).sum();
     let avg_size = total_size as f64 / instructions.len() as f64;
-    println!("\nAverage instruction size: {:.2} bytes", avg_size);
+    println!("\nAverage instruction size: {avg_size:.2} bytes");
 
     // Find jumps and calls
     let jumps: Vec<_> = instructions

--- a/tests/common/helpers.rs
+++ b/tests/common/helpers.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Test helper functions for threatflux-binary-analysis
 
 use std::io::Write;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Integration tests for the entire binary analysis pipeline
 
 use std::io::Write;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Test module organization and common utilities for threatflux-binary-analysis
 
 pub mod common;


### PR DESCRIPTION
## Summary
- Update README feature table to show Java enabled by default and document optional WASM and control-flow flags
- Add Feature Flags section to API reference
- Fix formatting in disassembly example and silence clippy's inline format warnings in tests

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo build --all-features`


------
https://chatgpt.com/codex/tasks/task_e_689fb4ae9210832795fd44962edd3a19