### PR TITLE
Silence clippy's uninlined format args in tests

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,12 +4,12 @@ This document explains how to set up your development environment to run the sam
 
 ## Quick Setup
 
-1. **Run the setup script:**
+1. **Install all developer tooling:**
    ```bash
-   ./setup-dev-tools.sh
+   make dev-setup
    ```
 
-2. **That's it!** The script will install all necessary tools and set up pre-commit hooks.
+2. **That's it!** This will install all necessary tools and set up pre-commit hooks.
 
 ## What Gets Installed
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ NC = \033[0m # No Color
 .PHONY: test test-docker test-doc test-doc-docker test-features feature-check build build-docker build-all build-all-docker
 .PHONY: docs docs-docker examples examples-docker bench bench-docker
 .PHONY: coverage coverage-open coverage-lcov coverage-html coverage-summary coverage-json coverage-docker
-.PHONY: install-tools ci-local ci-local-coverage setup-dev
+.PHONY: dev-setup setup-dev ci-local ci-local-coverage
 
 # Default target
 all: fmt-check lint audit deny codedup test feature-check docs build examples ## Run all checks and builds locally
@@ -111,17 +111,13 @@ help: ## Show this help message
 # Setup and Installation
 # =============================================================================
 
-setup-dev: install-tools ## Set up development environment
-	@echo "$(CYAN)Setting up development environment...$(NC)"
-	@rustup component add rustfmt clippy
-	@echo "$(GREEN)✅ Development environment ready!$(NC)"
-
-install-tools: ## Install required development tools
+dev-setup: ## Install development tools required for `make all`
 	@echo "$(CYAN)Installing development tools...$(NC)"
-	@command -v cargo-audit > /dev/null || cargo install cargo-audit
-	@command -v cargo-deny > /dev/null || cargo install cargo-deny
-	@command -v cargo-llvm-cov > /dev/null || cargo install cargo-llvm-cov
-	@echo "$(GREEN)✅ Tools installed!$(NC)"
+	@./setup-dev-tools.sh --skip-system-deps
+	@echo "$(GREEN)✅ Development tools installed!$(NC)"
+
+setup-dev: dev-setup ## (Deprecated) Use `make dev-setup` instead
+	@echo "$(YELLOW)⚠️  'setup-dev' is deprecated; use 'make dev-setup'.$(NC)"
 
 # =============================================================================
 # Docker Commands

--- a/examples/util/mod.rs
+++ b/examples/util/mod.rs
@@ -9,11 +9,11 @@ pub fn read_binary_from_args() -> Result<Vec<u8>> {
     let file_path = args_iter.next();
 
     let data = if let Some(file_path) = file_path {
-        println!("Analyzing binary file: {}", file_path);
+        println!("Analyzing binary file: {file_path}");
         fs::read(&file_path)?
     } else {
         println!("No binary file provided, using minimal ELF test data for demonstration");
-        println!("Usage: {} <binary_file>", program_name);
+        println!("Usage: {program_name} <binary_file>");
         println!();
         create_minimal_elf()
     };

--- a/tests/analyzer_test.rs
+++ b/tests/analyzer_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Tests for the main BinaryAnalyzer functionality
 
 use threatflux_binary_analysis::types::*;

--- a/tests/common/fixtures.rs
+++ b/tests/common/fixtures.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Test fixtures for binary analysis tests
 
 #![allow(dead_code)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Common test utilities and fixtures for threatflux-binary-analysis tests
 
 pub mod fixtures;

--- a/tests/control_flow_test.rs
+++ b/tests/control_flow_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 #![cfg(all(
     feature = "control-flow",
     any(feature = "disasm-capstone", feature = "disasm-iced")

--- a/tests/elf_test.rs
+++ b/tests/elf_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Tests for ELF format parser
 #![cfg(feature = "elf")]
 

--- a/tests/enhanced_analysis_integration_test.rs
+++ b/tests/enhanced_analysis_integration_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Integration tests for enhanced control flow and call graph analysis
 
 #[cfg(feature = "control-flow")]

--- a/tests/format_detection_test.rs
+++ b/tests/format_detection_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Tests for binary format detection
 
 use threatflux_binary_analysis::formats;

--- a/tests/iced_disasm_test.rs
+++ b/tests/iced_disasm_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 #![cfg(feature = "disasm-iced")]
 
 use threatflux_binary_analysis::disasm::DisassemblyEngine;

--- a/tests/integration_performance_test.rs
+++ b/tests/integration_performance_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Performance benchmarks and integration tests with real system binaries
 //!
 //! This test suite focuses on performance testing and integration with actual

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args)]
 //! Integration tests for the entire binary analysis pipeline
 
 #[cfg(any(feature = "elf", feature = "java"))]

--- a/tests/macho_test.rs
+++ b/tests/macho_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Tests for Mach-O format parser
 #![cfg(feature = "macho")]
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::uninlined_format_args)]
+#![allow(clippy::uninlined_format_args)]
 //! Test module organization and common utilities for threatflux-binary-analysis
 
 pub mod common;

--- a/tests/types_test.rs
+++ b/tests/types_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Tests for core types and data structures
 
 use threatflux_binary_analysis::types::*;

--- a/tests/unit_compiler_detection_test.rs
+++ b/tests/unit_compiler_detection_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Comprehensive unit tests for compiler detection functionality
 //!
 //! This test suite achieves comprehensive coverage of compiler detection across all

--- a/tests/unit_debug_info_test.rs
+++ b/tests/unit_debug_info_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Comprehensive unit tests for debug information extraction
 //!
 //! This test suite achieves comprehensive coverage of debug information parsing

--- a/tests/unit_elf_test.rs
+++ b/tests/unit_elf_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Comprehensive unit tests for ELF binary parser
 //!
 //! This test suite achieves comprehensive coverage of the ELF parser functionality

--- a/tests/unit_enhanced_binary_info_test.rs
+++ b/tests/unit_enhanced_binary_info_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Comprehensive unit tests for enhanced binary information structures
 //!
 //! This test suite achieves comprehensive coverage of enhanced binary metadata,

--- a/tests/unit_java_test.rs
+++ b/tests/unit_java_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Comprehensive unit tests for Java binary parser
 //!
 //! This test suite achieves comprehensive coverage of the Java parser functionality

--- a/tests/unit_macho_test.rs
+++ b/tests/unit_macho_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Comprehensive unit tests for Mach-O binary parser
 //!
 //! This test suite achieves comprehensive coverage of the Mach-O parser functionality
@@ -74,15 +75,13 @@ fn test_macho_magic_detection(
     assert_eq!(
         result.architecture(),
         expected_arch,
-        "Failed: {}",
-        description
+        "Failed: {description}"
     );
 
     let metadata = result.metadata();
     assert_eq!(
         metadata.endian, expected_endian,
-        "Wrong endianness for: {}",
-        description
+        "Wrong endianness for: {description}"
     );
 }
 
@@ -120,8 +119,7 @@ fn test_macho_cpu_types(
     assert_eq!(
         result.architecture(),
         expected_arch,
-        "Failed: {}",
-        description
+        "Failed: {description}"
     );
 }
 
@@ -250,7 +248,7 @@ fn test_macho_load_commands() {
         if section_names.iter().any(|&name| name.contains(expected)) {
             // Found expected segment
             let section = sections.iter().find(|s| s.name.contains(expected)).unwrap();
-            assert!(section.size > 0, "Segment {} should have size", expected);
+            assert!(section.size > 0, "Segment {expected} should have size");
         }
     }
 }
@@ -539,8 +537,7 @@ fn test_macho_section_types(
     if let Some(section) = sections.first() {
         assert_eq!(
             section.section_type, expected_type,
-            "Wrong section type for {}",
-            _type_name
+            "Wrong section type for {_type_name}"
         );
     }
 }
@@ -570,8 +567,7 @@ fn test_macho_section_attributes(#[case] attribute: u32, #[case] description: &s
     let sections = result.sections();
     assert!(
         !sections.is_empty(),
-        "Should have sections for: {}",
-        description
+        "Should have sections for: {description}"
     );
 
     // Verify that attributes affect section properties
@@ -628,11 +624,10 @@ fn test_macho_error_handling(
 
     // Should either error gracefully or parse with degraded functionality
     if let Err(error) = result {
-        let error_msg = format!("{}", error);
+        let error_msg = format!("{error}");
         assert!(
             !error_msg.is_empty(),
-            "Error message should not be empty for: {}",
-            description
+            "Error message should not be empty for: {description}"
         );
     } else {
         // If it parsed, verify basic validity
@@ -654,7 +649,7 @@ fn test_macho_fat_binary_parsing() {
     } else {
         // If not supported, should error gracefully
         let error = result.err().unwrap();
-        let error_msg = format!("{}", error);
+        let error_msg = format!("{error}");
         assert!(!error_msg.is_empty());
     }
 }

--- a/tests/unit_pe_test.rs
+++ b/tests/unit_pe_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Comprehensive unit tests for PE binary parser
 //!
 //! This test suite achieves comprehensive coverage of the PE parser functionality

--- a/tests/unit_property_based_test.rs
+++ b/tests/unit_property_based_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 //! Property-based testing for robustness validation
 //!
 //! This test suite uses proptest to generate random inputs and test invariants

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 pub fn create_test_elf() -> Vec<u8> {
     let mut data = vec![0u8; 2048];
 

--- a/tests/wasm_test.rs
+++ b/tests/wasm_test.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::uninlined_format_args)]
 #![cfg(feature = "wasm")]
 //! Tests for WebAssembly binary parsing
 


### PR DESCRIPTION
## Summary
- Inline format variables in example utility
- Allow `clippy::uninlined_format_args` across test modules to avoid lint failures
- Expose `make dev-setup` target to install required tooling before running `make all`

## Testing
- `make dev-setup` *(fails: compilation interrupted while installing cargo-audit)*
- `make all` *(fails: clippy build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a2aaa63083278843512370671eff