### PR TITLE
Complete Rust 1.95 validation after migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
     
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24  # v5.4.3
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
       with:
         files: lcov.info
         fail_ci_if_error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -141,7 +141,7 @@ jobs:
     - name: Install cargo-deny
       uses: taiki-e/install-action@4351b0c7eac445cb6f5a730526fcaef1473d3ea6  # v2.58.12
       with:
-        tool: cargo-deny
+        tool: cargo-deny@0.20.2
     
     - name: Check deny.toml exists
       id: check_deny

--- a/Makefile
+++ b/Makefile
@@ -125,10 +125,10 @@ setup-dev: dev-setup ## (Deprecated) Use `make dev-setup` instead
 
 docker-build: ## Build Docker image for consistent environment
 	@echo "$(CYAN)Building Docker image...$(NC)"
-	@echo 'FROM docker.io/threatflux/rust-cicd-template:base-rust-latest\n\
+	@echo 'FROM rust:1.95.0-bookworm\n\
 RUN apt-get update && apt-get install -y pkg-config libcapstone-dev musl-dev build-essential\n\
 RUN rustup component add rustfmt clippy\n\
-RUN cargo install cargo-chef cargo-audit cargo-deny cargo-llvm-cov\n\
+RUN cargo install --locked cargo-chef@0.1.77 cargo-audit@0.22.2 cargo-deny@0.20.2 cargo-llvm-cov@0.8.7 cargo-hack@0.6.45\n\
 WORKDIR /workspace\n\
 ENV CARGO_TERM_COLOR=always\n\
 ENV RUST_BACKTRACE=1\n\

--- a/tests/integration_performance_test.rs
+++ b/tests/integration_performance_test.rs
@@ -578,8 +578,8 @@ fn test_system_binary_integration() {
                 if let Ok(parsed) = parse_result {
                     println!("  Format: {:?}", parsed.format);
                     println!("  Architecture: {:?}", parsed.architecture);
-                    println!("  Sections: {}", &parsed.sections.len());
-                    println!("  Symbols: {}", &parsed.symbols.len());
+                    println!("  Sections: {}", parsed.sections.len());
+                    println!("  Symbols: {}", parsed.symbols.len());
 
                     // System binaries should parse successfully
                     assert_eq!(parsed.format, format);


### PR DESCRIPTION
## Summary
- Follow up the merged Rust 1.95 migration with the two defects found during current validation.
- Replace the drifting `base-rust-latest` Docker parent with exact `rust:1.95.0-bookworm`.
- Pin all validation tools to versions proven compatible with Rust 1.95 and include `cargo-hack` for feature-power-set checks.
- Remove two redundant formatting borrows rejected by current stable Clippy.

## Validation
- `RUSTUP_TOOLCHAIN=1.95.0 make ci-local`
- `RUSTUP_TOOLCHAIN=1.95.0 make feature-check` (102 combinations)
- Rust 1.95 and current-stable Clippy with all targets/features under `-D warnings`
- audit and deny checks (no vulnerabilities; warning-only unmaintained transitive `paste`)
- exact Rust 1.95.0 Docker build, pinned-tool version smoke test, and all-features container check
- workflow YAML and `git diff --check`

Signed head: `1267866b45de4220b1082587cb7b2fed19d0872c`.

This follow-up was opened because PR #14 merged externally while final validation was still in progress.
