### PR TITLE
ci: adopt ThreatFlux auto-release action

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,114 @@
+name: Auto Release
+
+concurrency:
+  group: auto-release-${{ github.event.workflow_run.head_branch || github.ref_name || 'main' }}
+  cancel-in-progress: true
+
+on:
+  workflow_run:
+    workflows: ["CI", "Security"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: Version bump type
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check for Release
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository) ||
+      github.event_name == 'workflow_dispatch'
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      should_release: ${{ steps.decide.outputs.should_release }}
+      target_sha: ${{ steps.target.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref_name }}
+
+      - name: Determine target SHA
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            if [[ ! "${WORKFLOW_RUN_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Invalid workflow-run head SHA" >&2
+              exit 1
+            fi
+            echo "sha=${WORKFLOW_RUN_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check CI status
+        id: ci_status
+        run: |
+          TARGET_SHA="${{ steps.target.outputs.sha }}"
+          CI_STATUS=$(gh run list --workflow=ci.yml --branch=main --commit="$TARGET_SHA" --event=push --limit=1 --json conclusion --jq '.[0].conclusion // ""')
+          SECURITY_STATUS=$(gh run list --workflow=security.yml --branch=main --commit="$TARGET_SHA" --event=push --limit=1 --json conclusion --jq '.[0].conclusion // ""')
+          if [[ "$CI_STATUS" == "success" ]] && [[ "$SECURITY_STATUS" == "success" ]]; then
+            echo "all_passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "all_passed=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide whether to attempt a release
+        id: decide
+        env:
+          ALL_PASSED: ${{ steps.ci_status.outputs.all_passed }}
+        run: |
+          # The release action itself no-ops when no conventional commit
+          # warrants a release, so this gate only enforces green required runs.
+          if [[ "${ALL_PASSED}" == "true" ]]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    name: Create Release
+    needs: check
+    if: needs.check.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ needs.check.outputs.target_sha }}
+
+      - name: Release
+        id: release
+        uses: ThreatFlux/github_actions/release@16d779cd569c34743eb6683ca4c0ce105e9ad234 # v0.4.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          bump: ${{ github.event.inputs.version_bump || 'auto' }}


### PR DESCRIPTION
Adopts the ThreatFlux auto-release action for this repo.

## What the action does

On every green push to `main`, `ThreatFlux/github_actions/release` inspects the conventional-commit history since the last tag, computes the next semver bump, rewrites the version in `Cargo.toml` and `Cargo.lock`, and creates the tag and GitHub Release entirely via the GitHub API — no `git` or `cargo` invocations at runtime. Merges that contain only `chore:`/`docs:`/`ci:` commits produce no release (the action no-ops). A `workflow_dispatch` trigger allows forcing a `patch`/`minor`/`major` bump manually.

## Gating

This repo uses the gated-both variant: the workflow fires on `workflow_run` completion of **CI** and **Security** on `main`, and the `check` job additionally verifies via `gh run list` that the *same commit* has a successful `push`-event run of both workflows before releasing.

## Tag-trigger limitation — please note

Tags created with `GITHUB_TOKEN` do **not** trigger tag-push workflows. This repo's `release.yml` (crates.io publish + GitHub release with the `.crate` artifact) is tag-push only and has **no `workflow_dispatch` trigger**, so it cannot be dispatch-chained from this workflow. As merged, an auto-release will create the tag and a GitHub Release, but `release.yml` will **not** fire automatically — the crates.io publish still needs a manual re-push of the tag with a PAT, or (recommended follow-up) adding a `workflow_dispatch` trigger to `release.yml` so the dispatch-chaining step can be added here.

## release.yml / docker.yml bug fixes

None applied:

- The suspected missing `shell: bash` on a "Build (native)" step does not exist in this repo — `release.yml` has no such step, and its only multi-line bash step running on the Windows matrix ("Verify tag and branch") already sets `shell: bash`.
- No indented-heredoc crates.io visibility check is present (publish is a plain `cargo publish --locked`).
- No Windows packaging step exists (this repo ships a `.crate`, not per-OS zips).
- There is no `docker.yml`.

## Pinning

The action ref is SHA-pinned to `ThreatFlux/github_actions/release@16d779cd…` (v0.4.2), as are the `actions/checkout` steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
