### PR TITLE
chore: migrate off the deprecated release sub-action and pin v0.7.1

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -108,7 +108,8 @@ jobs:
 
       - name: Release
         id: release
-        uses: ThreatFlux/github_actions/release@16d779cd569c34743eb6683ca4c0ce105e9ad234 # v0.4.2
+        uses: ThreatFlux/github_actions@99bd76d2bd4d2e79eaa18abe89de2c352bc1b9a2 # v0.7.1
         with:
+          command: release
           token: ${{ secrets.GITHUB_TOKEN }}
           bump: ${{ github.event.inputs.version_bump || 'auto' }}


### PR DESCRIPTION
Migrates this repository's release step off the **deprecated** `ThreatFlux/github_actions/release` sub-action and onto the unified action at [v0.7.1](https://github.com/ThreatFlux/github_actions/releases/tag/v0.7.1).

```diff
-        uses: ThreatFlux/github_actions/release@16d779cd569c34743eb6683ca4c0ce105e9ad234 # v0.4.2
+        uses: ThreatFlux/github_actions@99bd76d2bd4d2e79eaa18abe89de2c352bc1b9a2 # v0.7.1
         with:
+          command: release
           token: ${{ secrets.GITHUB_TOKEN }}
           bump: ${{ github.event.inputs.version_bump || 'auto' }}
```

## Why

This was the only ThreatFlux Rust repository still on the `/release` sub-action, and it was pinned at **v0.4.2** — roughly three minor releases behind. The upstream migration guide replaces that sub-action with the root action plus `command: release`, and the sub-action is slated for removal in the next major version.

v0.7.1 is also the first tag whose `runtime/Dockerfile` pin resolves to a matching prebuilt image; every tag through v0.7.0 executed a stale `0.6.2` binary regardless of the ref ([#57](https://github.com/ThreatFlux/github_actions/pull/57)).

## Compatibility

`token` and `bump` exist unchanged on the root action, so the inputs carry over as-is with only `command: release` added. I checked the rest of the workflow: nothing references `steps.release.outputs`, so no downstream wiring depends on this step. The root action exposes the same release outputs anyway if that changes later.
